### PR TITLE
Duplicate Resource Errors

### DIFF
--- a/manifests/profile/rabbitmq.pp
+++ b/manifests/profile/rabbitmq.pp
@@ -58,6 +58,7 @@ class st2::profile::rabbitmq (
     repos_ensure          => $repos_ensure,
     delete_guest_user     => true,
     port                  => $port,
+    manage_python         => false,
     environment_variables => {
       'RABBITMQ_NODE_IP_ADDRESS' => $::st2::rabbitmq_bind_ip,
     },


### PR DESCRIPTION
Telling rabbitmq to not manage python to avoid duplicate declaration errors in Puppet