### PR TITLE
update/use-python3-executable-for-scripts

### DIFF
--- a/files/st2_task_base.py
+++ b/files/st2_task_base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 import os
 import subprocess

--- a/tasks/key_decrypt.py
+++ b/tasks/key_decrypt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # TODO
 # This is a hack until 'st2 key load' and `st2 key set' accept encrypted values

--- a/tasks/key_get.py
+++ b/tasks/key_get.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 import os
 import sys

--- a/tasks/key_load.py
+++ b/tasks/key_load.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 import os
 import sys

--- a/tasks/pack_install.py
+++ b/tasks/pack_install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tasks/pack_list.py
+++ b/tasks/pack_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tasks/pack_register.py
+++ b/tasks/pack_register.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tasks/pack_remove.py
+++ b/tasks/pack_remove.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tasks/rule_disable.py
+++ b/tasks/rule_disable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tasks/rule_list.py
+++ b/tasks/rule_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tasks/run.py
+++ b/tasks/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 


### PR DESCRIPTION
Updated all python scripts to use python3 executable as python2 has been deprecated